### PR TITLE
pass through user-specified Interests Button label

### DIFF
--- a/gatsby-theme-portfolio-minimal/src/sections/Interests/index.tsx
+++ b/gatsby-theme-portfolio-minimal/src/sections/Interests/index.tsx
@@ -40,7 +40,7 @@ export function InterestsSection(props: PageSection): React.ReactElement {
                     })}
                     {shouldShowButton && shownInterests < data.interests.length && (
                         <Animation type="scaleIn" delay={(shownInterests + 1) * 100}>
-                            <Button type={ButtonType.BUTTON} onClickHandler={loadMoreHandler} label="+ Load more" />
+                            <Button type={ButtonType.BUTTON} onClickHandler={loadMoreHandler} label={data.button.label} />
                         </Animation>
                     )}
                 </div>


### PR DESCRIPTION
This pull request for your review should allow the user to specify the button label in the Interests section.  Please let me know if there are other places that also have dependencies, I can add them to this PR as well.

Thank you very much Konstantin for your theme.  Am loving it! ❤️