### PR TITLE
Adding Facebook as an available icon

### DIFF
--- a/gatsby-theme-portfolio-minimal/content/sections/contact/contact.example.json
+++ b/gatsby-theme-portfolio-minimal/content/sections/contact/contact.example.json
@@ -4,7 +4,8 @@
     "description": "",
     "image": {
         "src": "",
-        "alt": ""
+        "alt": "",
+        "objectFit": ""
     },
     "socialProfiles": {
         "from": [""],

--- a/gatsby-theme-portfolio-minimal/content/sections/hero/hero.example.json
+++ b/gatsby-theme-portfolio-minimal/content/sections/hero/hero.example.json
@@ -6,7 +6,8 @@
     },
     "image": {
         "src": "",
-        "alt": ""
+        "alt": "",
+        "objectFit": ""
     },
     "title": "",
     "subtitle": {

--- a/gatsby-theme-portfolio-minimal/content/sections/interests/interests.example.json
+++ b/gatsby-theme-portfolio-minimal/content/sections/interests/interests.example.json
@@ -4,7 +4,8 @@
             "label": "",
             "image": {
                 "src": "",
-                "alt": ""
+                "alt": "",
+                "objectFit": ""
             }
         }
     ],

--- a/gatsby-theme-portfolio-minimal/content/sections/projects/projects.example.json
+++ b/gatsby-theme-portfolio-minimal/content/sections/projects/projects.example.json
@@ -9,7 +9,8 @@
             "image": {
                 "src": "",
                 "alt": "",
-                "linkTo": ""
+                "linkTo": "",
+                "objectFit": ""
             },
             "links": [
                 {

--- a/gatsby-theme-portfolio-minimal/src/components/ArticleCard/index.tsx
+++ b/gatsby-theme-portfolio-minimal/src/components/ArticleCard/index.tsx
@@ -38,6 +38,7 @@ export function ArticleCard(props: ArticleCardProps): React.ReactElement {
                         <GatsbyImage
                             className={classes.ImageWrapper}
                             imgClassName={classes.Image}
+                            objectFit={props.data.image.objectFit || 'cover'}
                             image={props.data.image.src.childImageSharp.gatsbyImageData}
                             alt={props.data.image.alt || props.data.title}
                         />

--- a/gatsby-theme-portfolio-minimal/src/components/Icon/IconFacebook.tsx
+++ b/gatsby-theme-portfolio-minimal/src/components/Icon/IconFacebook.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+interface IconFacebookProps {
+    color?: string;
+}
+
+export function IconFacebook(props: IconFacebookProps): React.ReactElement {
+    return (
+		<svg
+  viewBox="0.993 1 14.007 13.915" 
+  height="48" 
+  width="48" 
+  focusable="false"
+            role="img"
+  fill={props.color || 'var(--primary-color)'}
+  xmlns="http://www.w3.org/2000/svg">
+  
+  <path d="M15 8a7 7 0 0 0-7-7 7 7 0 0 0-1.094 13.915v-4.892H5.13V8h1.777V6.458c0-1.754 1.045-2.724 2.644-2.724.766 0 1.567.137 1.567.137v1.723h-.883c-.87 0-1.14.54-1.14 1.093V8h1.941l-.31 2.023H9.094v4.892A7.001 7.001 0 0 0 15 8z"/>
+
+</svg>
+    );
+}

--- a/gatsby-theme-portfolio-minimal/src/components/Icon/index.tsx
+++ b/gatsby-theme-portfolio-minimal/src/components/Icon/index.tsx
@@ -21,6 +21,7 @@ import { IconStackOverflow } from './IconStackOverflow';
 import { IconTwitch } from './IconTwitch';
 import { IconYouTube } from './IconYouTube';
 import { IconUntappd } from './IconUntappd';
+import { IconFacebook } from './IconFacebook';
 
 interface IconProps {
     name: string;
@@ -73,6 +74,8 @@ export function Icon(props: IconProps): React.ReactElement | null {
             return <IconYouTube color={props.color} />;
         case 'untappd':
             return <IconUntappd color={props.color} />;
+        case 'facebook':
+            return <IconFacebook color={props.color} />;
         default:
             return null;
     }

--- a/gatsby-theme-portfolio-minimal/src/components/Project/index.tsx
+++ b/gatsby-theme-portfolio-minimal/src/components/Project/index.tsx
@@ -78,6 +78,7 @@ export function Project(props: ProjectProps): React.ReactElement {
                     <GatsbyImage
                         className={classes.ProjectImageWrapper}
                         imgClassName={classes.ProjectImage}
+                        objectFit={props.data.image.objectFit}
                         image={props.data.image.src.childImageSharp.gatsbyImageData}
                         alt={props.data.image.alt || `Project ${props.data.title}`}
                     />
@@ -87,6 +88,7 @@ export function Project(props: ProjectProps): React.ReactElement {
                 <GatsbyImage
                     className={classes.ProjectImageWrapper}
                     imgClassName={classes.ProjectImage}
+                    objectFit={props.data.image.objectFit}
                     image={props.data.image.src.childImageSharp.gatsbyImageData}
                     alt={props.data.image.alt || `Project ${props.data.title}`}
                 />

--- a/gatsby-theme-portfolio-minimal/src/components/SocialProfiles/configuration.ts
+++ b/gatsby-theme-portfolio-minimal/src/components/SocialProfiles/configuration.ts
@@ -20,4 +20,5 @@ export const socialProfileLabels = {
     patreon: 'Patreon',
     reddit: 'Reddit',
     untappd: 'Untappd',
+    facebook: 'Facebook'
 };

--- a/gatsby-theme-portfolio-minimal/src/components/SocialProfiles/index.tsx
+++ b/gatsby-theme-portfolio-minimal/src/components/SocialProfiles/index.tsx
@@ -27,6 +27,7 @@ export enum SocialProfile {
     Patreon = 'patreon',
     Reddit = 'reddit',
     Untappd = 'untappd',
+    Facebook = 'facebook'
 }
 
 interface SocialProfilesProps {

--- a/gatsby-theme-portfolio-minimal/src/gatsby/node/createSchemaCustomization.js
+++ b/gatsby-theme-portfolio-minimal/src/gatsby/node/createSchemaCustomization.js
@@ -87,6 +87,7 @@ module.exports = ({ actions }) => {
         patreon: String
         buymeacoffee: String
         untappd: String
+        facebook: String
     }
     type Logo {
         text: String

--- a/gatsby-theme-portfolio-minimal/src/gatsby/node/createSchemaCustomization.js
+++ b/gatsby-theme-portfolio-minimal/src/gatsby/node/createSchemaCustomization.js
@@ -15,11 +15,13 @@ module.exports = ({ actions }) => {
     type Image {
         src: File @fileByRelativePath
         alt: String
+        objectFit: String
     }
     type LinkedImage {
         src: File @fileByRelativePath
         alt: String
         linkTo: String
+        objectFit: String
     }
     type SocialProfiles {
         from: [String!]!

--- a/gatsby-theme-portfolio-minimal/src/hooks/useSiteMetadata.tsx
+++ b/gatsby-theme-portfolio-minimal/src/hooks/useSiteMetadata.tsx
@@ -68,6 +68,7 @@ export const query = graphql`
                         patreon
                         reddit
                         untappd
+                        facebook
                     }
                     titleTemplate
                 }

--- a/gatsby-theme-portfolio-minimal/src/sections/Contact/data.tsx
+++ b/gatsby-theme-portfolio-minimal/src/sections/Contact/data.tsx
@@ -31,6 +31,7 @@ export const useLocalDataSource = (): ContactSectionQueryResult => {
                                 gatsbyImageData(width: 140)
                             }
                         }
+                        objectFit
                     }
                     name
                     socialProfiles {

--- a/gatsby-theme-portfolio-minimal/src/sections/Hero/data.tsx
+++ b/gatsby-theme-portfolio-minimal/src/sections/Hero/data.tsx
@@ -51,6 +51,7 @@ export const useLocalDataSource = (): HeroSectionQueryResult => {
                                 gatsbyImageData(width: 48, aspectRatio: 1)
                             }
                         }
+                        objectFit
                     }
                     intro
                     socialProfiles {

--- a/gatsby-theme-portfolio-minimal/src/sections/Interests/data.tsx
+++ b/gatsby-theme-portfolio-minimal/src/sections/Interests/data.tsx
@@ -35,6 +35,7 @@ export const useLocalDataSource = (): InterestsSectionQueryResult => {
                                     gatsbyImageData(width: 20, height: 20)
                                 }
                             }
+                            objectFit
                         }
                         label
                     }

--- a/gatsby-theme-portfolio-minimal/src/sections/Projects/data.tsx
+++ b/gatsby-theme-portfolio-minimal/src/sections/Projects/data.tsx
@@ -35,6 +35,7 @@ export const useLocalDataSource = (): ProjectsSectionQueryResult => {
                                     gatsbyImageData(width: 400)
                                 }
                             }
+                            objectFit
                         }
                         links {
                             type

--- a/gatsby-theme-portfolio-minimal/src/types.d.ts
+++ b/gatsby-theme-portfolio-minimal/src/types.d.ts
@@ -14,6 +14,7 @@ interface ImageObject {
             gatsbyImageData: IGatsbyImageData;
         };
     } | null;
+    objectFit?: 'cover' | 'contain' | 'fill' | 'none' | 'scale-down';
 }
 
 interface PageSection {


### PR DESCRIPTION
## What?

Adding Facebook as an available social icon.

## Why

I'd like to be able to use the theme and also have the Facebook social icon as standard, and reading on to #20 it'd be good to have one of the major social platforms available to use. 

## How
1. Add the link to `settings.json` - otherwise this will not show if you add it to the `socialProfiles` variable.
2. Add `IconFacebook` as an import and in the case statement in `gatsby-theme-portfolio-minimal/src/components/Icon/index.tsx`
3. Add `facebook` in the const list in `gatsby-theme-portfolio-minimal/src/components/SocialProfiles/configuration.ts`
4. Add `Facebook` in the enum in `gatsby-theme-portfolio-minimal/src/components/SocialProfiles/index.tsx`
5. Set `facebook` as a string in `gatsby-theme-portfolio-minimal/src/gatsby/node/createSchemaCustomization.js`
6. Add `facebook` to the graphql query in `gatsby-theme-portfolio-minimal/src/hooks/useSiteMetadata.tsx`
7. Add the SVG to `gatsby-theme-portfolio-minimal\src\components\Icon\Icon<iconname>.tsx` 

### SVG
To get the SVG to work, I used a [web SVG editor](https://www.svgviewer.dev/), setting the height at 48x48 and letting this provide the SVG.

