### PR TITLE
Fix error when AboutSection has no image specified

### DIFF
--- a/gatsby-theme-portfolio-minimal/src/gatsby/node/createPages.js
+++ b/gatsby-theme-portfolio-minimal/src/gatsby/node/createPages.js
@@ -10,21 +10,23 @@ module.exports = async ({ graphql, actions, reporter }, options) => {
     if (!data && response.errors) {
         throw new Error(`Error while fetching article data, ${response.errors}`);
     } else if (data.allArticle.articles.length !== 0 && (!options.blogSettings || !options.blogSettings.path)) {
+        // Throw error if there are articles in the content/articles folder, but blog settings have not been configured
         throw new Error(`No path for ArticleListing page in gatsby-config specified`);
     }
 
-    // Create ArticleListing page
-    const articleListingPageSlug = options.blogSettings.path.replace(/\/\/+/g, '/'); // remove duplicate slashes
-    reporter.info(`Creating ArticleListing page under ${articleListingPageSlug}`);
-    actions.createPage({
-        path: articleListingPageSlug,
-        component: path.resolve(templateDir, 'ArticleListing', 'index.tsx'),
-        context: {
-            articles: data.allArticle.articles,
-            entityName: options.blogSettings.entityName,
-        },
-    });
-
+    // Create ArticleListing page if blog settings have been configured 
+    if (options.blogSettings && options.blogSettings.path) {
+        const articleListingPageSlug = options.blogSettings.path.replace(/\/\/+/g, '/'); // remove duplicate slashes
+        reporter.info(`Creating ArticleListing page under ${articleListingPageSlug}`);
+        actions.createPage({
+            path: articleListingPageSlug,
+            component: path.resolve(templateDir, 'ArticleListing', 'index.tsx'),
+            context: {
+                articles: data.allArticle.articles,
+                entityName: options.blogSettings.entityName,
+            },
+        });
+    }
     // Create pages for each individual Article
     data.allArticle.articles.forEach((article) => {
         reporter.info(`Creating Article page under ${article.slug}`);

--- a/gatsby-theme-portfolio-minimal/src/sections/About/index.tsx
+++ b/gatsby-theme-portfolio-minimal/src/sections/About/index.tsx
@@ -15,15 +15,20 @@ export function AboutSection(props: PageSection): React.ReactElement {
             <Section anchor={props.sectionId} heading={props.heading}>
                 <div className={classes.About}>
                     <div className={classes.Description} dangerouslySetInnerHTML={{ __html: data.html }} />
-                    <Animation type="fadeLeft" delay={200}>
-                        <div className={classes.ImageWrapper}>
-                            <GatsbyImage
-                                image={data.frontmatter.imageSrc.childImageSharp.gatsbyImageData}
-                                className={classes.Image}
-                                alt={data.frontmatter.imageAlt || `About Image`}
-                            />
-                        </div>
-                    </Animation>
+                        {data.frontmatter.imageSrc ?
+                        <Animation type="fadeLeft" delay={200}>
+                            <div className={classes.ImageWrapper}>
+                                {<GatsbyImage
+                                    image={data.frontmatter.imageSrc.childImageSharp.gatsbyImageData}
+                                    className={classes.Image}
+                                    alt={data.frontmatter.imageAlt || `About Image`}
+                                />
+                                }
+                            </div>
+                        </Animation>
+                        :
+                        null
+                    }
                 </div>
             </Section>
         </Animation>


### PR DESCRIPTION
I ran into two errors while doing initial setup using this repo.
https://imgur.com/a/oJA1pRX

One triggers during the build step if there are no articles in the articles folder, and no blog settings have been configured.

The other triggers if you use the AboutSection, but don't provide an image in the about markdown template.

fixes:
* Articles page is only created if there is a path provided in the blog settings for it to be created at
* If no image is provided, no image is rendered