### PR TITLE
+Add support for multiple sections

### DIFF
--- a/example-site/content/sections/interests/hobbies.json
+++ b/example-site/content/sections/interests/hobbies.json
@@ -1,0 +1,30 @@
+{
+    "interests": [
+        {
+            "label": "Gaming",
+            "image": {
+                "src": "../../images/joystick.png",
+                "alt": ""
+            }
+        },
+        {
+            "label": "Surfing the Web",
+            "image": {
+                "src": "../../images/notebook.png",
+                "alt": ""
+            }
+        },
+        {
+            "label": "Mobile Games",
+            "image": {
+                "src": "../../images/mobile-phone.png",
+                "alt": ""
+            }
+        }
+    ],
+    "button": {
+        "visible": false,
+        "label": "+ Load More",
+        "initiallyShownInterests": 5
+    }
+}

--- a/example-site/content/sections/projects/more_projects.json
+++ b/example-site/content/sections/projects/more_projects.json
@@ -1,0 +1,26 @@
+{
+    "projects": [
+        {
+            "visible": true,
+            "category": "🧰 EXTENDABLE LAYOUT",
+            "title": "Multiple Project sections!",
+            "description": "You can now use more than one projects/*.json file to define separate Projects sections. Photo by Kelly Sikkema on Unsplash.",
+            "tags": ["Custom Sections", "Easy-2-Use"],
+            "image": {
+                "src": "../../images/kelly-sikkema-Hl3LUdyKRic-unsplash.jpg",
+                "alt": "Extendable Layout"
+            },
+            "links": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/konstantinmuenster/gatsby-starter-portfolio-minimal-theme"
+                }
+            ]
+        }
+    ],
+    "button": {
+        "visible": true,
+        "label": "Test it now",
+        "url": "https://github.com/konstantinmuenster/gatsby-theme-portfolio-minimal"
+    }
+}

--- a/example-site/src/pages/index.js
+++ b/example-site/src/pages/index.js
@@ -21,6 +21,7 @@ export default function IndexPage() {
                 <InterestsSection sectionId="details" heading="Details" />
                 <ProjectsSection sectionId="features" heading="Built-in Features" />
                 <ProjectsSection sectionId="more-features" heading="Advanced Features" fileName="more_projects" />
+                <InterestsSection sectionId="hobbies" heading="Hobbies" fileName="hobbies" />
                 <ContactSection sectionId="github" heading="Issues?" />
             </Page>
         </>

--- a/example-site/src/pages/index.js
+++ b/example-site/src/pages/index.js
@@ -20,6 +20,7 @@ export default function IndexPage() {
                 <AboutSection sectionId="about" heading="About Portfolio Minimal" />
                 <InterestsSection sectionId="details" heading="Details" />
                 <ProjectsSection sectionId="features" heading="Built-in Features" />
+                <ProjectsSection sectionId="more-features" heading="Advanced Features" fileName="more_projects" />
                 <ContactSection sectionId="github" heading="Issues?" />
             </Page>
         </>

--- a/gatsby-theme-portfolio-minimal/README.md
+++ b/gatsby-theme-portfolio-minimal/README.md
@@ -276,7 +276,7 @@ The following table shows which section components are available and how they ca
 | ------------------ | --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
 | `AboutSection`     | `sectionId` _(required)_ <br/> `heading` _(optional)_ <br/> `fileName` _(optional, default: "about")_     | `*contentRootDir*/sections/about/*fileName*.md`       |
 | `ContactSection`   | `sectionId` _(required)_ <br/> `heading` _(optional)_ <br/> `fileName` _(optional, default: "contact")_   | `*contentRootDir*/sections/contact/*fileName*.json`   |
-| `HeroSection`      | `sectionId` _(required)_                                                                                  | `*contentRootDir*/sections/hero/*yourFile*.json`      |
+| `HeroSection`      | `sectionId` _(required)_ <br/> `fileName` _(optional, default: "hero")_                                   | `*contentRootDir*/sections/hero/*yourFile*.json`      |
 | `InterestsSection` | `sectionId` _(required)_ <br/> `heading` _(optional)_ <br/> `fileName` _(optional, default: "interests")_ | `*contentRootDir*/sections/interests/*fileName*.json` |
 | `LegalSection`     | `sectionId` _(required)_ <br/> `heading` _(optional)_                                                     | `*contentRootDir*/sections/legal/*yourFile*.md`       |
 | `ProjectsSection`  | `sectionId` _(required)_ <br/> `heading` _(optional)_ <br/> `fileName` _(optional, default: "projects")_  | `*contentRootDir*/sections/projects/*fileName*.json`  |

--- a/gatsby-theme-portfolio-minimal/README.md
+++ b/gatsby-theme-portfolio-minimal/README.md
@@ -197,6 +197,7 @@ content
     │     └── imprint.md # has to be Markdown
     │ └── projects
     │     └── projects.json # has to be JSON
+    |     └── more_projects.json # has to be JSON
 ```
 
 #### `settings.json` File
@@ -270,14 +271,14 @@ Most section components work the following way: You import and configure the com
 
 The following table shows which section components are available and how they can be configured.
 
-| Section Component  | Available Props                                       | Associated Content File                               |
-| ------------------ | ----------------------------------------------------- | ----------------------------------------------------- |
-| `AboutSection`     | `sectionId` _(required)_ <br/> `heading` _(optional)_ | `*contentRootDir*/sections/about/*yourFile*.md`       |
-| `ContactSection`   | `sectionId` _(required)_ <br/> `heading` _(optional)_ | `*contentRootDir*/sections/contact/*yourFile*.json`   |
-| `HeroSection`      | `sectionId` _(required)_                              | `*contentRootDir*/sections/hero/*yourFile*.json`      |
-| `InterestsSection` | `sectionId` _(required)_ <br/> `heading` _(optional)_ | `*contentRootDir*/sections/interests/*yourFile*.json` |
-| `LegalSection`     | `sectionId` _(required)_ <br/> `heading` _(optional)_ | `*contentRootDir*/sections/legal/*yourFile*.md`       |
-| `ProjectsSection`  | `sectionId` _(required)_ <br/> `heading` _(optional)_ | `*contentRootDir*/sections/projects/*yourFile*.json`  |
+| Section Component  | Available Props                                                                                          | Associated Content File                               |
+|--------------------|----------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
+| `AboutSection`     | `sectionId` _(required)_ <br/> `heading` _(optional)_                                                    | `*contentRootDir*/sections/about/*yourFile*.md`       |
+| `ContactSection`   | `sectionId` _(required)_ <br/> `heading` _(optional)_                                                    | `*contentRootDir*/sections/contact/*yourFile*.json`   |
+| `HeroSection`      | `sectionId` _(required)_                                                                                 | `*contentRootDir*/sections/hero/*yourFile*.json`      |
+| `InterestsSection` | `sectionId` _(required)_ <br/> `heading` _(optional)_                                                    | `*contentRootDir*/sections/interests/*yourFile*.json` |
+| `LegalSection`     | `sectionId` _(required)_ <br/> `heading` _(optional)_                                                    | `*contentRootDir*/sections/legal/*yourFile*.md`       |
+| `ProjectsSection`  | `sectionId` _(required)_ <br/> `heading` _(optional)_ <br/> `fileName` _(optional, default: "projects")_ | `*contentRootDir*/sections/projects/*fileName*.json`  |
 
 #### Utility Components
 

--- a/gatsby-theme-portfolio-minimal/README.md
+++ b/gatsby-theme-portfolio-minimal/README.md
@@ -273,8 +273,8 @@ Most section components work the following way: You import and configure the com
 The following table shows which section components are available and how they can be configured.
 
 | Section Component  | Available Props                                                                                           | Associated Content File                               |
-|--------------------|-----------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
-| `AboutSection`     | `sectionId` _(required)_ <br/> `heading` _(optional)_                                                     | `*contentRootDir*/sections/about/*yourFile*.md`       |
+| ------------------ | --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| `AboutSection`     | `sectionId` _(required)_ <br/> `heading` _(optional)_ <br/> `fileName` _(optional, default: "about")_     | `*contentRootDir*/sections/about/*fileName*.md`       |
 | `ContactSection`   | `sectionId` _(required)_ <br/> `heading` _(optional)_                                                     | `*contentRootDir*/sections/contact/*yourFile*.json`   |
 | `HeroSection`      | `sectionId` _(required)_                                                                                  | `*contentRootDir*/sections/hero/*yourFile*.json`      |
 | `InterestsSection` | `sectionId` _(required)_ <br/> `heading` _(optional)_ <br/> `fileName` _(optional, default: "interests")_ | `*contentRootDir*/sections/interests/*fileName*.json` |

--- a/gatsby-theme-portfolio-minimal/README.md
+++ b/gatsby-theme-portfolio-minimal/README.md
@@ -275,7 +275,7 @@ The following table shows which section components are available and how they ca
 | Section Component  | Available Props                                                                                           | Associated Content File                               |
 | ------------------ | --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
 | `AboutSection`     | `sectionId` _(required)_ <br/> `heading` _(optional)_ <br/> `fileName` _(optional, default: "about")_     | `*contentRootDir*/sections/about/*fileName*.md`       |
-| `ContactSection`   | `sectionId` _(required)_ <br/> `heading` _(optional)_                                                     | `*contentRootDir*/sections/contact/*yourFile*.json`   |
+| `ContactSection`   | `sectionId` _(required)_ <br/> `heading` _(optional)_ <br/> `fileName` _(optional, default: "contact")_   | `*contentRootDir*/sections/contact/*fileName*.json`   |
 | `HeroSection`      | `sectionId` _(required)_                                                                                  | `*contentRootDir*/sections/hero/*yourFile*.json`      |
 | `InterestsSection` | `sectionId` _(required)_ <br/> `heading` _(optional)_ <br/> `fileName` _(optional, default: "interests")_ | `*contentRootDir*/sections/interests/*fileName*.json` |
 | `LegalSection`     | `sectionId` _(required)_ <br/> `heading` _(optional)_                                                     | `*contentRootDir*/sections/legal/*yourFile*.md`       |

--- a/gatsby-theme-portfolio-minimal/README.md
+++ b/gatsby-theme-portfolio-minimal/README.md
@@ -193,6 +193,7 @@ content
     │     └── hero.json # has to be JSON
     │ └── interests
     │     └── interests.json # has to be JSON
+    │     └── more_interests.json # has to be JSON
     │ └── legal
     │     └── imprint.md # has to be Markdown
     │ └── projects
@@ -271,14 +272,14 @@ Most section components work the following way: You import and configure the com
 
 The following table shows which section components are available and how they can be configured.
 
-| Section Component  | Available Props                                                                                          | Associated Content File                               |
-|--------------------|----------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
-| `AboutSection`     | `sectionId` _(required)_ <br/> `heading` _(optional)_                                                    | `*contentRootDir*/sections/about/*yourFile*.md`       |
-| `ContactSection`   | `sectionId` _(required)_ <br/> `heading` _(optional)_                                                    | `*contentRootDir*/sections/contact/*yourFile*.json`   |
-| `HeroSection`      | `sectionId` _(required)_                                                                                 | `*contentRootDir*/sections/hero/*yourFile*.json`      |
-| `InterestsSection` | `sectionId` _(required)_ <br/> `heading` _(optional)_                                                    | `*contentRootDir*/sections/interests/*yourFile*.json` |
-| `LegalSection`     | `sectionId` _(required)_ <br/> `heading` _(optional)_                                                    | `*contentRootDir*/sections/legal/*yourFile*.md`       |
-| `ProjectsSection`  | `sectionId` _(required)_ <br/> `heading` _(optional)_ <br/> `fileName` _(optional, default: "projects")_ | `*contentRootDir*/sections/projects/*fileName*.json`  |
+| Section Component  | Available Props                                                                                           | Associated Content File                               |
+|--------------------|-----------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
+| `AboutSection`     | `sectionId` _(required)_ <br/> `heading` _(optional)_                                                     | `*contentRootDir*/sections/about/*yourFile*.md`       |
+| `ContactSection`   | `sectionId` _(required)_ <br/> `heading` _(optional)_                                                     | `*contentRootDir*/sections/contact/*yourFile*.json`   |
+| `HeroSection`      | `sectionId` _(required)_                                                                                  | `*contentRootDir*/sections/hero/*yourFile*.json`      |
+| `InterestsSection` | `sectionId` _(required)_ <br/> `heading` _(optional)_ <br/> `fileName` _(optional, default: "interests")_ | `*contentRootDir*/sections/interests/*fileName*.json` |
+| `LegalSection`     | `sectionId` _(required)_ <br/> `heading` _(optional)_                                                     | `*contentRootDir*/sections/legal/*yourFile*.md`       |
+| `ProjectsSection`  | `sectionId` _(required)_ <br/> `heading` _(optional)_ <br/> `fileName` _(optional, default: "projects")_  | `*contentRootDir*/sections/projects/*fileName*.json`  |
 
 #### Utility Components
 

--- a/gatsby-theme-portfolio-minimal/src/sections/About/data.tsx
+++ b/gatsby-theme-portfolio-minimal/src/sections/About/data.tsx
@@ -2,35 +2,47 @@ import { graphql, useStaticQuery } from 'gatsby';
 import { IGatsbyImageData } from 'gatsby-plugin-image';
 
 interface AboutSectionQueryResult {
-    allAboutMarkdown: {
-        sections: {
-            frontmatter: {
-                imageAlt?: string;
-                imageSrc?: {
-                    childImageSharp: {
-                        gatsbyImageData: IGatsbyImageData;
+    allFile: {
+        aboutFiles: {
+            name: string;
+            relativePath: string;
+            section: {
+                frontmatter: {
+                    imageAlt?: string;
+                    imageSrc?: {
+                        childImageSharp: {
+                            gatsbyImageData: IGatsbyImageData;
+                        };
                     };
                 };
-            };
-            html: string;
+                html: string;
+            }[];
         }[];
     };
 }
 
 export const useLocalDataSource = (): AboutSectionQueryResult => {
     return useStaticQuery(graphql`
-        query AboutSectionQuery {
-            allAboutMarkdown: allMarkdownRemark(filter: { fileAbsolutePath: { regex: "/sections/about/" } }) {
-                sections: nodes {
-                    frontmatter {
-                        imageAlt
-                        imageSrc {
-                            childImageSharp {
-                                gatsbyImageData(width: 400)
+        query AboutByFilename {
+            allFile(
+                filter: { childMarkdownRemark: { id: { ne: null } }, relativePath: { regex: "/sections/about/" } }
+            ) {
+                aboutFiles: nodes {
+                    name
+                    relativePath
+                    section: children {
+                        ... on MarkdownRemark {
+                            frontmatter {
+                                imageAlt
+                                imageSrc {
+                                    childImageSharp {
+                                        gatsbyImageData(width: 400)
+                                    }
+                                }
                             }
+                            html
                         }
                     }
-                    html
                 }
             }
         }

--- a/gatsby-theme-portfolio-minimal/src/sections/About/index.tsx
+++ b/gatsby-theme-portfolio-minimal/src/sections/About/index.tsx
@@ -8,20 +8,25 @@ import * as classes from './style.module.css';
 
 export function AboutSection(props: PageSection): React.ReactElement {
     const response = useLocalDataSource();
-    const data = response.allAboutMarkdown.sections[0];
+    const allFiles = response.allFile.aboutFiles;
+    const fileNameNeedle = props.fileName ? props.fileName : 'about';
+    const result = allFiles.find((file) => {
+        return file.name == fileNameNeedle;
+    });
+    const section = result ? result.section[0] : allFiles[0].section[0];
 
     return (
         <Animation type="fadeUp">
             <Section anchor={props.sectionId} heading={props.heading}>
                 <div className={classes.About}>
-                    <div className={classes.Description} dangerouslySetInnerHTML={{ __html: data.html }} />
-                    {data.frontmatter.imageSrc && (
+                    <div className={classes.Description} dangerouslySetInnerHTML={{ __html: section.html }} />
+                    {section.frontmatter.imageSrc && (
                         <Animation type="fadeLeft" delay={200}>
                             <div className={classes.ImageWrapper}>
                                 <GatsbyImage
-                                    image={data.frontmatter.imageSrc.childImageSharp.gatsbyImageData}
+                                    image={section.frontmatter.imageSrc.childImageSharp.gatsbyImageData}
                                     className={classes.Image}
-                                    alt={data.frontmatter.imageAlt || `About Image`}
+                                    alt={section.frontmatter.imageAlt || `About Image`}
                                 />
                             </div>
                         </Animation>

--- a/gatsby-theme-portfolio-minimal/src/sections/Contact/data.tsx
+++ b/gatsby-theme-portfolio-minimal/src/sections/Contact/data.tsx
@@ -3,40 +3,50 @@ import { SocialProfile } from '../../components/SocialProfiles';
 import { ImageObject } from '../../types';
 
 interface ContactSectionQueryResult {
-    allContactJson: {
-        sections: {
-            description: string;
-            email: string;
-            image: ImageObject;
+    allFile: {
+        contactFiles: {
             name: string;
-            socialProfiles: {
-                from: SocialProfile[];
-                showIcons: boolean;
-            };
+            relativePath: string;
+            section: {
+                description: string;
+                email: string;
+                image: ImageObject;
+                name: string;
+                socialProfiles: {
+                    from: SocialProfile[];
+                    showIcons: boolean;
+                };
+            }[];
         }[];
     };
 }
 
 export const useLocalDataSource = (): ContactSectionQueryResult => {
     return useStaticQuery(graphql`
-        query ContactSectionQuery {
-            allContactJson {
-                sections: nodes {
-                    description
-                    email
-                    image {
-                        alt
-                        src {
-                            childImageSharp {
-                                gatsbyImageData(width: 140)
+        query ContactsByFilename {
+            allFile(filter: { childContactJson: { id: { ne: null } } }) {
+                contactFiles: nodes {
+                    name
+                    relativePath
+                    section: children {
+                        ... on ContactJson {
+                            description
+                            email
+                            image {
+                                alt
+                                src {
+                                    childImageSharp {
+                                        gatsbyImageData(width: 140)
+                                    }
+                                }
+                                objectFit
+                            }
+                            name
+                            socialProfiles {
+                                from
+                                showIcons
                             }
                         }
-                        objectFit
-                    }
-                    name
-                    socialProfiles {
-                        from
-                        showIcons
                     }
                 }
             }

--- a/gatsby-theme-portfolio-minimal/src/sections/Contact/index.tsx
+++ b/gatsby-theme-portfolio-minimal/src/sections/Contact/index.tsx
@@ -9,29 +9,34 @@ import * as classes from './style.module.css';
 
 export function ContactSection(props: PageSection): React.ReactElement {
     const response = useLocalDataSource();
-    const data = response.allContactJson.sections[0];
+    const allFiles = response.allFile.contactFiles;
+    const fileNameNeedle = props.fileName ? props.fileName : 'contact';
+    const result = allFiles.find((file) => {
+        return file.name == fileNameNeedle;
+    });
+    const section = result ? result.section[0] : allFiles[0].section[0];
 
     return (
         <Animation type="fadeUp">
             <Section anchor={props.sectionId} heading={props.heading} additionalClasses={[classes.Contact]}>
-                {data.description && <p className={classes.Description}>{data.description}</p>}
+                {section.description && <p className={classes.Description}>{section.description}</p>}
                 <div className={classes.Profile}>
-                    {data.image.src && (
+                    {section.image.src && (
                         <GatsbyImage
                             className={classes.Avatar}
-                            image={data.image.src.childImageSharp.gatsbyImageData}
-                            alt={data.image.alt || `Profile ${data.name}`}
+                            image={section.image.src.childImageSharp.gatsbyImageData}
+                            alt={section.image.alt || `Profile ${section.name}`}
                         />
                     )}
                     <div className={classes.ContactDetails}>
-                        <div className={classes.Name}>{data.name}</div>
+                        <div className={classes.Name}>{section.name}</div>
                         <u>
-                            <a href={`mailto:${data.email}`}>{data.email}</a>
+                            <a href={`mailto:${section.email}`}>{section.email}</a>
                         </u>
                     </div>
                 </div>
-                {data.socialProfiles && (
-                    <SocialProfiles from={data.socialProfiles.from} showIcon={data.socialProfiles.showIcons} />
+                {section.socialProfiles && (
+                    <SocialProfiles from={section.socialProfiles.from} showIcon={section.socialProfiles.showIcons} />
                 )}
             </Section>
         </Animation>

--- a/gatsby-theme-portfolio-minimal/src/sections/Hero/data.tsx
+++ b/gatsby-theme-portfolio-minimal/src/sections/Hero/data.tsx
@@ -3,73 +3,83 @@ import { SocialProfile } from '../../components/SocialProfiles';
 import { ImageObject } from '../../types';
 
 interface HeroSectionQueryResult {
-    allHeroJson: {
-        sections: {
-            description: string;
-            email: string;
-            image: ImageObject;
-            intro: string;
-            heroPhoto: ImageObject;
-            socialProfiles: {
-                from: SocialProfile[];
-                showIcons: boolean;
-            };
-            calendly: {
-                label: string;
-                username: string;
-                colorText: string;
-                colorButton: string;
-            };
-            subtitle: {
-                highlight: string;
-                prefix: string;
-                suffix: string;
-            };
-            title: string;
+    allFile: {
+        heroFiles: {
+            name: string;
+            relativePath: string;
+            section: {
+                description: string;
+                email: string;
+                image: ImageObject;
+                intro: string;
+                heroPhoto: ImageObject;
+                socialProfiles: {
+                    from: SocialProfile[];
+                    showIcons: boolean;
+                };
+                calendly: {
+                    label: string;
+                    username: string;
+                    colorText: string;
+                    colorButton: string;
+                };
+                subtitle: {
+                    highlight: string;
+                    prefix: string;
+                    suffix: string;
+                };
+                title: string;
+            }[];
         }[];
     };
 }
 
 export const useLocalDataSource = (): HeroSectionQueryResult => {
     return useStaticQuery(graphql`
-        query HeroSectionQuery {
-            allHeroJson {
-                sections: nodes {
-                    description
-                    heroPhoto {
-                        src {
-                            childImageSharp {
-                                gatsbyImageData(aspectRatio: 1)
+        query HerosByFilename {
+            allFile(filter: { childHeroJson: { id: { ne: null } } }) {
+                heroFiles: nodes {
+                    name
+                    relativePath
+                    section: children {
+                        ... on HeroJson {
+                            description
+                            heroPhoto {
+                                src {
+                                    childImageSharp {
+                                        gatsbyImageData(aspectRatio: 1)
+                                    }
+                                }
+                                alt
                             }
-                        }
-                        alt
-                    }
-                    image {
-                        alt
-                        src {
-                            childImageSharp {
-                                gatsbyImageData(width: 48, aspectRatio: 1)
+                            image {
+                                alt
+                                src {
+                                    childImageSharp {
+                                        gatsbyImageData(width: 48, aspectRatio: 1)
+                                    }
+                                }
+                                objectFit
                             }
+                            intro
+                            socialProfiles {
+                                from
+                                showIcons
+                            }
+                            calendly {
+                                label
+                                username
+                                colorText
+                                colorButton
+                            }
+                            subtitle {
+                                highlight
+                                prefix
+                                suffix
+                            }
+                            title
                         }
-                        objectFit
                     }
-                    intro
-                    socialProfiles {
-                        from
-                        showIcons
-                    }
-                    calendly {
-                        label
-                        username
-                        colorText
-                        colorButton
-                    }
-                    subtitle {
-                        highlight
-                        prefix
-                        suffix
-                    }
-                    title
                 }
             }
         }

--- a/gatsby-theme-portfolio-minimal/src/sections/Hero/index.tsx
+++ b/gatsby-theme-portfolio-minimal/src/sections/Hero/index.tsx
@@ -10,47 +10,55 @@ import * as classes from './style.module.css';
 
 export function HeroSection(props: PageSection): React.ReactElement {
     const response = useLocalDataSource();
-    const data = response.allHeroJson.sections[0];
+    const allFiles = response.allFile.heroFiles;
+    const fileNameNeedle = props.fileName ? props.fileName : 'projects';
+    const result = allFiles.find((file) => {
+        return file.name == fileNameNeedle;
+    });
+    const section = result ? result.section[0] : allFiles[0].section[0];
 
-    const CalendlyWidget = useCalendlyWidget(data.calendly);
+    const CalendlyWidget = useCalendlyWidget(section.calendly);
 
     return (
         <Animation type="fadeUp" delay={400}>
             {CalendlyWidget}
             <Section anchor={props.sectionId} additionalClasses={[classes.HeroContainer]}>
-                {data.heroPhoto?.src && (
+                {section.heroPhoto?.src && (
                     <div className={classes.heroImageCont}>
                         <GatsbyImage
                             className={classes.heroImage}
-                            image={data.heroPhoto.src.childImageSharp.gatsbyImageData}
-                            alt={data.heroPhoto.alt || `Profile Image`}
+                            image={section.heroPhoto.src.childImageSharp.gatsbyImageData}
+                            alt={section.heroPhoto.alt || `Profile Image`}
                             loading="eager"
                         />
                     </div>
                 )}
                 <div className={classes.Hero}>
                     <div className={classes.Intro}>
-                        {data.intro && <span className={classes.ImagePrefix}>{data.intro}</span>}
-                        {data.image?.src && (
+                        {section.intro && <span className={classes.ImagePrefix}>{section.intro}</span>}
+                        {section.image?.src && (
                             <Animation className={classes.Image} type="waving-hand" duration={2500} iterationCount={3}>
                                 <GatsbyImage
-                                    image={data.image.src.childImageSharp.gatsbyImageData}
-                                    alt={data.image.alt || `Intro Image`}
+                                    image={section.image.src.childImageSharp.gatsbyImageData}
+                                    alt={section.image.alt || `Intro Image`}
                                     loading="eager"
                                 />
                             </Animation>
                         )}
                     </div>
-                    <h1 className={classes.Title}>{data.title}</h1>
+                    <h1 className={classes.Title}>{section.title}</h1>
                     <h2 className={classes.Subtitle}>
-                        {data.subtitle.prefix}
-                        <u>{data.subtitle.highlight}</u>
-                        {data.subtitle.suffix}
+                        {section.subtitle.prefix}
+                        <u>{section.subtitle.highlight}</u>
+                        {section.subtitle.suffix}
                     </h2>
-                    <p>{data.description}</p>
+                    <p>{section.description}</p>
                     <Animation type="fadeLeft" delay={600}>
-                        {data.socialProfiles && (
-                            <SocialProfiles from={data.socialProfiles.from} showIcon={data.socialProfiles.showIcons} />
+                        {section.socialProfiles && (
+                            <SocialProfiles
+                                from={section.socialProfiles.from}
+                                showIcon={section.socialProfiles.showIcons}
+                            />
                         )}
                     </Animation>
                 </div>

--- a/gatsby-theme-portfolio-minimal/src/sections/Interests/data.tsx
+++ b/gatsby-theme-portfolio-minimal/src/sections/Interests/data.tsx
@@ -2,16 +2,20 @@ import { graphql, useStaticQuery } from 'gatsby';
 import { ImageObject } from '../../types';
 
 interface InterestsSectionQueryResult {
-    allInterestsJson: {
-        sections: {
-            button: {
-                initiallyShownInterests: number;
-                label: string;
-                visible: boolean;
-            };
-            interests: {
-                image: ImageObject;
-                label: string;
+    allFile: {
+        interestsFiles: {
+            name: string;
+            relativePath: string;
+            section: {
+                button: {
+                    initiallyShownInterests: number;
+                    label: string;
+                    visible: boolean;
+                };
+                interests: {
+                    image: ImageObject;
+                    label: string;
+                }[];
             }[];
         }[];
     };
@@ -19,25 +23,31 @@ interface InterestsSectionQueryResult {
 
 export const useLocalDataSource = (): InterestsSectionQueryResult => {
     return useStaticQuery(graphql`
-        query InterestsSectionQuery {
-            allInterestsJson {
-                sections: nodes {
-                    button {
-                        initiallyShownInterests
-                        label
-                        visible
-                    }
-                    interests {
-                        image {
-                            alt
-                            src {
-                                childImageSharp {
-                                    gatsbyImageData(width: 20, height: 20)
-                                }
+        query InterestsByFilename {
+            allFile(filter: { childInterestsJson: { id: { ne: null } } }) {
+                interestsFiles: nodes {
+                    name
+                    relativePath
+                    section: children {
+                        ... on InterestsJson {
+                            button {
+                                initiallyShownInterests
+                                label
+                                visible
                             }
-                            objectFit
+                            interests {
+                                image {
+                                    alt
+                                    src {
+                                        childImageSharp {
+                                            gatsbyImageData(width: 20, height: 20)
+                                        }
+                                    }
+                                    objectFit
+                                }
+                                label
+                            }
                         }
-                        label
                     }
                 }
             }

--- a/gatsby-theme-portfolio-minimal/src/sections/Interests/index.tsx
+++ b/gatsby-theme-portfolio-minimal/src/sections/Interests/index.tsx
@@ -9,22 +9,27 @@ import * as classes from './style.module.css';
 
 export function InterestsSection(props: PageSection): React.ReactElement {
     const response = useLocalDataSource();
-    const data = response.allInterestsJson.sections[0];
-    const shouldShowButton = data.button.visible !== false;
-    const initiallyShownInterests = data.button.initiallyShownInterests ?? 5;
+    const allFiles = response.allFile.interestsFiles;
+    const fileNameNeedle = props.fileName ? props.fileName : 'interests';
+    const result = allFiles.find((file) => {
+        return file.name == fileNameNeedle;
+    });
+    const section = result ? result.section[0] : allFiles[0].section[0];
+    const shouldShowButton = section.button.visible !== false;
+    const initiallyShownInterests = section.button.initiallyShownInterests ?? 5;
     const [shownInterests, setShownInterests] = React.useState<number>(
-        shouldShowButton ? initiallyShownInterests : data.interests.length,
+        shouldShowButton ? initiallyShownInterests : section.interests.length,
     );
 
     function loadMoreHandler() {
-        setShownInterests(data.interests.length);
+        setShownInterests(section.interests.length);
     }
 
     return (
         <Animation type="fadeUp">
             <Section anchor={props.sectionId} heading={props.heading}>
                 <div className={classes.Interests}>
-                    {data.interests.slice(0, shownInterests).map((interest, key) => {
+                    {section.interests.slice(0, shownInterests).map((interest, key) => {
                         return (
                             <Animation key={key} className={classes.Interest} type="scaleIn" delay={key * 100}>
                                 {interest.image.src && (
@@ -38,12 +43,12 @@ export function InterestsSection(props: PageSection): React.ReactElement {
                             </Animation>
                         );
                     })}
-                    {shouldShowButton && shownInterests < data.interests.length && (
+                    {shouldShowButton && shownInterests < section.interests.length && (
                         <Animation type="scaleIn" delay={(shownInterests + 1) * 100}>
                             <Button
                                 type={ButtonType.BUTTON}
                                 onClickHandler={loadMoreHandler}
-                                label={data.button.label}
+                                label={section.button.label}
                             />
                         </Animation>
                     )}

--- a/gatsby-theme-portfolio-minimal/src/sections/Projects/data.tsx
+++ b/gatsby-theme-portfolio-minimal/src/sections/Projects/data.tsx
@@ -2,48 +2,58 @@ import { graphql, useStaticQuery } from 'gatsby';
 import { Project } from '../../components/Project';
 
 interface ProjectsSectionQueryResult {
-    allProjectsJson: {
-        sections: {
-            button: {
-                label: string;
-                url: string;
-                visible: boolean;
-            };
-            projects: Project[];
+    allFile: {
+        projectFiles: {
+            name: string;
+            relativePath: string;
+            section: {
+                button: {
+                    label: string;
+                    url: string;
+                    visible: boolean;
+                };
+                projects: Project[];
+            }[];
         }[];
     };
 }
 
 export const useLocalDataSource = (): ProjectsSectionQueryResult => {
     return useStaticQuery(graphql`
-        query ProjectsSectionQuery {
-            allProjectsJson {
-                sections: nodes {
-                    button {
-                        label
-                        url
-                        visible
-                    }
-                    projects {
-                        category
-                        description
-                        image {
-                            alt
-                            linkTo
-                            src {
-                                childImageSharp {
-                                    gatsbyImageData(width: 400)
-                                }
+        query ProjectsByFilename {
+            allFile(filter: { childProjectsJson: { id: { ne: null } } }) {
+                projectFiles: nodes {
+                    name
+                    relativePath
+                    section: children {
+                        ... on ProjectsJson {
+                            button {
+                                label
+                                url
+                                visible
                             }
-                            objectFit
+                            projects {
+                                category
+                                description
+                                image {
+                                    alt
+                                    linkTo
+                                    src {
+                                        childImageSharp {
+                                            gatsbyImageData(width: 400)
+                                        }
+                                    }
+                                    objectFit
+                                }
+                                links {
+                                    type
+                                    url
+                                }
+                                tags
+                                title
+                                visible
+                            }
                         }
-                        links {
-                            type
-                            url
-                        }
-                        tags
-                        title
-                        visible
                     }
                 }
             }

--- a/gatsby-theme-portfolio-minimal/src/sections/Projects/index.tsx
+++ b/gatsby-theme-portfolio-minimal/src/sections/Projects/index.tsx
@@ -10,23 +10,28 @@ import * as classes from './style.module.css';
 
 export function ProjectsSection(props: PageSection): React.ReactElement {
     const response = useLocalDataSource();
-    const data = response.allProjectsJson.sections[0];
+    const allFiles = response.allFile.projectFiles;
+    const fileNameNeedle = props.fileName ? props.fileName : 'projects';
+    const result = allFiles.find((file) => {
+        return file.name == fileNameNeedle;
+    });
+    const section = result ? result.section[0] : allFiles[0].section[0];
 
     return (
         <Animation type="fadeIn">
             <Section anchor={props.sectionId} heading={props.heading}>
                 <Slider additionalClasses={[classes.Projects]}>
-                    {data.projects.map((project, key) => {
+                    {section.projects.map((project, key) => {
                         return project.visible ? <Project key={key} index={key} data={project} /> : null;
                     })}
                 </Slider>
-                {data.button !== undefined && data.button.visible !== false && (
+                {section.button !== undefined && section.button.visible !== false && (
                     <Animation className={classes.MoreProjects} type="fadeIn">
                         <Button
                             type={ButtonType.LINK}
                             externalLink={true}
-                            url={data.button.url}
-                            label={data.button.label}
+                            url={section.button.url}
+                            label={section.button.label}
                         />
                     </Animation>
                 )}

--- a/gatsby-theme-portfolio-minimal/src/types.d.ts
+++ b/gatsby-theme-portfolio-minimal/src/types.d.ts
@@ -20,6 +20,7 @@ interface ImageObject {
 interface PageSection {
     sectionId: string;
     heading?: string;
+    fileName?: string;
 }
 
 interface GatsbyNodeHelpers {


### PR DESCRIPTION

Fix for #21

Started with `Projects` and will port the same mechanism to the other sections as well. But feel free to give some feedback already, especially on the typescript best practices (got virtually 0 experience there)!

### Summary
It queries for `File` nodes instead of specific `*Json` nodes now, and filters inside the component. Not ideal (the filtering could happen in graphql already), but that its the only way possible with staticQueries (and without variables).

Updated the documentation to the best of my knowledge. The example content could be a lot more creative.

#### Progress
- [x] About
- [x] Contact
- [x] Hero
- [x] Interests
- [ ] ~~Legal~~ already contains a filtering mechanism
- [x] Projects
